### PR TITLE
Add signRepodata to AddRPM/RemoveRPM to regenerate signed repo metadata

### DIFF
--- a/cmd/rpmrepo-update/main.go
+++ b/cmd/rpmrepo-update/main.go
@@ -77,9 +77,9 @@ func run(ctx context.Context, args []string) error {
 	case "init":
 		return runInit(ctx, backendType, repoRoot, s3Opts, logLevel, signRepodata, gpgKey, remaining[1:])
 	case "add":
-		return runAdd(ctx, backendType, repoRoot, s3Opts, logLevel, signRPMs, gpgKey, remaining[1:])
+		return runAdd(ctx, backendType, repoRoot, s3Opts, logLevel, signRPMs, signRepodata, gpgKey, remaining[1:])
 	case "remove":
-		return runRemove(ctx, backendType, repoRoot, s3Opts, logLevel, remaining[1:])
+		return runRemove(ctx, backendType, repoRoot, s3Opts, logLevel, signRepodata, gpgKey, remaining[1:])
 	case "check":
 		return runCheck(ctx, backendType, repoRoot, s3Opts, logLevel, outputFormat, remaining[1:])
 	default:
@@ -125,7 +125,7 @@ func runInit(ctx context.Context, backendType, repoRoot string, s3Opts s3Options
 	return nil
 }
 
-func runAdd(ctx context.Context, backendType, repoRoot string, s3Opts s3Options, logLevel string, signRPMs bool, gpgKey string, args []string) error {
+func runAdd(ctx context.Context, backendType, repoRoot string, s3Opts s3Options, logLevel string, signRPMs bool, signRepodata bool, gpgKey string, args []string) error {
 	fs := flag.NewFlagSet("add", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	var replaceExisting bool
@@ -166,7 +166,7 @@ func runAdd(ctx context.Context, backendType, repoRoot string, s3Opts s3Options,
 	}
 	r.AllowUnknown = allowUnknown
 	r.DestPrefix = destPrefix
-	if err := r.AddRPMs(ctx, rpmPaths, replaceExisting, dryRun, signRPMs, gpgKey); err != nil {
+	if err := r.AddRPMs(ctx, rpmPaths, replaceExisting, dryRun, signRPMs, signRepodata, gpgKey); err != nil {
 		return err
 	}
 	if dryRun {
@@ -181,7 +181,7 @@ func runAdd(ctx context.Context, backendType, repoRoot string, s3Opts s3Options,
 	return nil
 }
 
-func runRemove(ctx context.Context, backendType, repoRoot string, s3Opts s3Options, logLevel string, args []string) error {
+func runRemove(ctx context.Context, backendType, repoRoot string, s3Opts s3Options, logLevel string, signRepodata bool, gpgKey string, args []string) error {
 	fs := flag.NewFlagSet("remove", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	var deleteFiles bool
@@ -214,7 +214,7 @@ func runRemove(ctx context.Context, backendType, repoRoot string, s3Opts s3Optio
 		return err
 	}
 	r.AllowUnknown = allowUnknown
-	if err := r.RemoveRPMs(ctx, ids, byNEVRA, deleteFiles, dryRun); err != nil {
+	if err := r.RemoveRPMs(ctx, ids, byNEVRA, deleteFiles, dryRun, signRepodata, gpgKey); err != nil {
 		return err
 	}
 	if dryRun {

--- a/pkg/repo/add.go
+++ b/pkg/repo/add.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AddRPMs adds RPMs to the repository, updating core metadata. Only filesystem/S3 backends are supported in v1.
-func (r *Repo) AddRPMs(ctx context.Context, rpmPaths []string, replaceExisting bool, dryRun bool, signRPMs bool, gpgKey string) error {
+func (r *Repo) AddRPMs(ctx context.Context, rpmPaths []string, replaceExisting bool, dryRun bool, signRPMs bool, signRepodata bool, gpgKey string) error {
 	if r.backend == nil {
 		return fmt.Errorf("backend is required")
 	}
@@ -82,5 +82,5 @@ func (r *Repo) AddRPMs(ctx context.Context, rpmPaths []string, replaceExisting b
 	if dryRun {
 		return nil
 	}
-	return r.writeMetadata(ctx, md, pkgs, checksumAlg, now)
+	return r.writeMetadata(ctx, md, pkgs, checksumAlg, now, signRepodata, gpgKey)
 }

--- a/pkg/repo/meta.go
+++ b/pkg/repo/meta.go
@@ -49,7 +49,7 @@ func (r *Repo) loadPackages(ctx context.Context) (metadata.RepoMD, []metadata.Pa
 }
 
 // writeMetadata regenerates core metadata and repomd.xml, writing via backend.
-func (r *Repo) writeMetadata(ctx context.Context, md metadata.RepoMD, pkgs []metadata.Package, checksumAlg string, now time.Time) error {
+func (r *Repo) writeMetadata(ctx context.Context, md metadata.RepoMD, pkgs []metadata.Package, checksumAlg string, now time.Time, signRepodata bool, gpgKey string) error {
 	if validator, ok := r.backend.(RepomdValidator); ok {
 		if err := validator.CheckRepomdUnchanged(ctx); err != nil {
 			return err
@@ -77,6 +77,12 @@ func (r *Repo) writeMetadata(ctx context.Context, md metadata.RepoMD, pkgs []met
 	}
 	if err := r.backend.WriteFile(ctx, "repodata/repomd.xml", repomdBytes); err != nil {
 		return fmt.Errorf("write repodata/repomd.xml: %w", err)
+	}
+
+	if signRepodata {
+		if err := r.signRepomd(ctx, repomdBytes, gpgKey); err != nil {
+			return fmt.Errorf("sign repomd.xml: %w", err)
+		}
 	}
 
 	// Clean up old metadata files no longer referenced

--- a/pkg/repo/remove.go
+++ b/pkg/repo/remove.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RemoveRPMs removes packages identified by filename (default) or NEVRA. Optionally deletes RPM files.
-func (r *Repo) RemoveRPMs(ctx context.Context, identifiers []string, byNEVRA bool, deleteFiles bool, dryRun bool) error {
+func (r *Repo) RemoveRPMs(ctx context.Context, identifiers []string, byNEVRA bool, deleteFiles bool, dryRun bool, signRepodata bool, gpgKey string) error {
 	if len(identifiers) == 0 {
 		return fmt.Errorf("no identifiers provided")
 	}
@@ -63,5 +63,5 @@ func (r *Repo) RemoveRPMs(ctx context.Context, identifiers []string, byNEVRA boo
 	if dryRun {
 		return nil
 	}
-	return r.writeMetadata(ctx, md, kept, checksumAlg, now)
+	return r.writeMetadata(ctx, md, kept, checksumAlg, now, signRepodata, gpgKey)
 }

--- a/pkg/repo/repo_flow_test.go
+++ b/pkg/repo/repo_flow_test.go
@@ -43,7 +43,7 @@ func TestRemoveRPMsMetadataOnly(t *testing.T) {
 	mb.files["foo-1.0-1.x86_64.rpm"] = []byte("rpmdata")
 
 	r := New(mb)
-	if err := r.RemoveRPMs(ctx, []string{"foo-1.0-1.x86_64.rpm"}, false, true, false); err != nil {
+	if err := r.RemoveRPMs(ctx, []string{"foo-1.0-1.x86_64.rpm"}, false, true, false, false, ""); err != nil {
 		t.Fatalf("RemoveRPMs: %v", err)
 	}
 	_, pkgsOut, _, err := r.loadPackages(ctx)
@@ -72,7 +72,7 @@ func TestWriteMetadataConflict(t *testing.T) {
 	pkgs := []metadata.Package{}
 	now := time.Unix(0, 0)
 	md := metadata.RepoMD{}
-	err := (&Repo{backend: cb, logger: newTestLogger(t)}).writeMetadata(ctx, md, pkgs, "sha256", now)
+	err := (&Repo{backend: cb, logger: newTestLogger(t)}).writeMetadata(ctx, md, pkgs, "sha256", now, false, "")
 	if err == nil {
 		t.Fatalf("expected conflict error")
 	}


### PR DESCRIPTION
While using this utility, I found that adding or removing RPMs from a repository with signed metadata and `repo_gpgcheck=1` set in the repo file would result in an invalid signature error when trying to use the repository. 

Add repomd.xml signing to add/remove operations since repomd.xml changes, which invalidates the signed file.